### PR TITLE
Collapse commands in config onto one line.

### DIFF
--- a/keymap.ron
+++ b/keymap.ron
@@ -5,11 +5,7 @@
         esc: ("Reload Log", [reload_log]),
         enter: (
             "Accept",
-            [
-                accept(
-                    "{change:selected}",
-                ),
-            ],
+            [accept("{change:selected}")],
         ),
         "y": (
             "Yank Change IDs",
@@ -32,86 +28,31 @@
         "s": ("Squash...", []),
         "rr": (
             "Rebase revision on selected",
-            [
-                jj(
-                    [
-                        "rebase",
-                        "-r={change:focused}",
-                        "-d=all:{change:selected_revset}",
-                    ],
-                ),
-            ],
+            [jj(["rebase", "-r={change:focused}", "-d=all:{change:selected_revset}"])],
         ),
         "rs": (
             "Rebase source on selected",
-            [
-                jj(
-                    [
-                        "rebase",
-                        "-s={change:focused}",
-                        "-d=all:{change:selected_revset}",
-                    ],
-                ),
-            ],
+            [jj(["rebase", "-s={change:focused}", "-d=all:{change:selected_revset}"])],
         ),
         "rb": (
             "Rebase branch on selected",
-            [
-                jj(
-                    [
-                        "rebase",
-                        "-b={change:focused}",
-                        "-d=all:{change:selected_revset}",
-                    ],
-                ),
-            ],
+            [jj(["rebase", "-b={change:focused}", "-d=all:{change:selected_revset}"])],
         ),
         "tr": (
             "Rebase revision (@) on trunk",
-            [
-                jj(
-                    [
-                        "rebase",
-                        "-r=@",
-                        "-d=trunk()",
-                    ],
-                ),
-            ],
+            [jj(["rebase", "-r=@", "-d=trunk()"])],
         ),
         "ts": (
             "Rebase source (@) on trunk",
-            [
-                jj(
-                    [
-                        "rebase",
-                        "-s=@",
-                        "-d=trunk()",
-                    ],
-                ),
-            ],
+            [jj(["rebase", "-s=@", "-d=trunk()"])],
         ),
         "tb": (
             "Rebase branch (@) on trunk",
-            [
-                jj(
-                    [
-                        "rebase",
-                        "-b=@",
-                        "-d=trunk()",
-                    ],
-                ),
-            ],
+            [jj(["rebase", "-b=@", "-d=trunk()"])],
         ),
         "n": (
             "New on selected",
-            [
-                jj(
-                    [
-                        "new",
-                        "all:{change:selected_revset}",
-                    ],
-                ),
-            ],
+            [jj(["new", "all:{change:selected_revset}", ])],
         ),
         "tn": (
             "New on trunk",
@@ -119,108 +60,39 @@
         ),
         "e": (
             "Edit focused",
-            [
-                jj(
-                    [
-                        "edit",
-                        "{change:focused}",
-                    ],
-                ),
-            ],
+            [jj(["edit", "{change:focused}"])],
         ),
         "d": (
             "Describe focused",
-            [
-                jji(
-                    [
-                        "describe",
-                        "{change:focused}",
-                    ],
-                ),
-            ],
+            [jji(["describe", "{change:focused}"])],
         ),
         "a": (
             "Abandon selected",
-            [
-                jj(
-                    [
-                        "abandon",
-                        "{change:selected_revset}",
-                    ],
-                ),
-            ],
+            [jj(["abandon", "{change:selected_revset}"])],
         ),
         "@rr": (
             "Rebase wc revision on selected",
-            [
-                jj(
-                    [
-                        "rebase",
-                        "-r=@",
-                        "-d=all:{change:selected_revset}",
-                    ],
-                ),
-            ],
+            [jj(["rebase", "-r=@", "-d=all:{change:selected_revset}"])],
         ),
         "@rs": (
             "Rebase wc source on selected",
-            [
-                jj(
-                    [
-                        "rebase",
-                        "-s=@",
-                        "-d=all:{change:selected_revset}",
-                    ],
-                ),
-            ],
+            [jj(["rebase", "-s=@", "-d=all:{change:selected_revset}"])],
         ),
         "@rb": (
             "Rebase wc branch on selected",
-            [
-                jj(
-                    [
-                        "rebase",
-                        "-b=@",
-                        "-d=all:{change:selected_revset}",
-                    ],
-                ),
-            ],
+            [jj(["rebase", "-b=@", "-d=all:{change:selected_revset}"])],
         ),
         "@tr": (
             "Rebase wc revision on trunk",
-            [
-                jj(
-                    [
-                        "rebase",
-                        "-r=@",
-                        "-d=trunk()",
-                    ],
-                ),
-            ],
+            [jj(["rebase", "-r=@", "-d=trunk()"])],
         ),
         "@ts": (
             "Rebase wc source on trunk",
-            [
-                jj(
-                    [
-                        "rebase",
-                        "-s=@",
-                        "-d=trunk()",
-                    ],
-                ),
-            ],
+            [jj(["rebase", "-s=@", "-d=trunk()"])],
         ),
         "@tb": (
             "Rebase wc branch on trunk",
-            [
-                jj(
-                    [
-                        "rebase",
-                        "-b=@",
-                        "-d=trunk()",
-                    ],
-                ),
-            ],
+            [jj(["rebase", "-b=@", "-d=trunk()"])],
         ),
         "@n": (
             "New on wc",
@@ -237,38 +109,15 @@
         "S": ("Status", [jj(["status"])]),
         "s-": (
             "Squash into parent",
-            [
-                jj(
-                    [
-                        "squash",
-                        "--from={change:selected_revset}",
-                        "--into={change:focused}-",
-                    ],
-                ),
-            ],
+            [jj(["squash", "--from={change:selected_revset}", "--into={change:focused}-"])],
         ),
         "si": (
             "Squash selected into focused",
-            [
-                jj(
-                    [
-                        "squash",
-                        "--from={change:selected_revset}",
-                        "--into={change:focused}",
-                    ],
-                ),
-            ],
+            [jj(["squash", "--from={change:selected_revset}", "--into={change:focused}"])],
         ),
         "s@": (
             "Squash selected into wc",
-            [
-                jj(
-                    [
-                        "squash",
-                        "--from={change:selected_revset}",
-                    ],
-                ),
-            ],
+            [jj(["squash", "--from={change:selected_revset}"])],
         ),
         "@s-": (
             "Squash wc into parent",
@@ -276,14 +125,7 @@
         ),
         "@si": (
             "Squash wc into focused",
-            [
-                jj(
-                    [
-                        "squash",
-                        "--into={change:focused}",
-                    ],
-                ),
-            ],
+            [jj(["squash", "--into={change:focused}"])],
         ),
         "gf": (
             "Git fetch",
@@ -295,73 +137,27 @@
         ),
         "gpc": (
             "Git push (--change focused)",
-            [
-                jj(
-                    [
-                        "git",
-                        "push",
-                        "--change={change:focused}",
-                    ],
-                ),
-            ],
+            [jj(["git", "push", "--change={change:focused}"])],
         ),
         "@-gpc": (
             "Git push (--change @-)",
-            [
-                jj(
-                    [
-                        "git",
-                        "push",
-                        "--change=@-",
-                    ],
-                ),
-            ],
+            [jj(["git", "push", "--change=@-"])],
         ),
         " ": (
             "Show focused",
-            [
-                jj(
-                    [
-                        "--ignore-working-copy",
-                        "show",
-                        "{change:focused}",
-                    ],
-                ),
-            ],
+            [jj(["--ignore-working-copy", "show", "{change:focused}"])],
         ),
         "@ ": (
             "Show wc",
-            [
-                jj(
-                    [
-                        "--ignore-working-copy",
-                        "show",
-                        "@",
-                    ],
-                ),
-            ],
+            [jj(["--ignore-working-copy", "show", "@"])],
         ),
         "@- ": (
             "Show parent of wc",
-            [
-                jj(
-                    [
-                        "--ignore-working-copy",
-                        "show",
-                        "@",
-                    ],
-                ),
-            ],
+            [jj(["--ignore-working-copy", "show", "@"])],
         ),
         "o": (
             "Show obslog of focused",
-            [
-                mode(
-                    obslog(
-                        "{change:focused}",
-                    ),
-                ),
-            ],
+            [mode(obslog("{change:focused}"))],
         ),
         "@o": (
             "Show obslog of wc",
@@ -373,33 +169,19 @@
         ),
         "c": (
             "Commit",
-            [
-                jji(
-                    [
-                        "commit",
-                        "--interactive",
-                    ],
-                ),
-            ],
+            [jji(["commit", "--interactive"])],
         ),
     },
     "revset": {
         esc: ("Normal Mode", [mode(normal)]),
-        enter: (
-            "Set Revset",
-            [change_revset("{query}")],
-        ),
+        enter: ("Set Revset", [change_revset("{query}")]),
     },
     "obslog": {
         "q": ("Quit", [quit]),
         esc: ("Normal Mode", [mode(normal)]),
         enter: (
             "Accept",
-            [
-                accept(
-                    "{commit:selected}",
-                ),
-            ],
+            [accept("{commit:select}")],
         ),
         "y": (
             "Yank Commit IDs",


### PR DESCRIPTION
Makes the file a lot more bearable to read and edit in my opinion. Feel free to ignore if you disagree and prefer the expanded form.